### PR TITLE
#147: move getcwd call to expected location

### DIFF
--- a/ex7_building_modeling_optimization.ipynb
+++ b/ex7_building_modeling_optimization.ipynb
@@ -76,16 +76,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CWD = os.getcwd() # workaround: PyPRT initialization unexpectedly changes current working directory\n",
-    "DATA = os.path.join(CWD, 'data')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import pyprt\n",
     "pyprt.initialize_prt()\n",
     "\n",
@@ -126,6 +116,16 @@
    "metadata": {},
    "source": [
     "### Given: building architecture (CGA Rule Package) and parcel to redevelop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CWD = os.getcwd()\n",
+    "DATA = os.path.join(CWD, 'data')"
    ]
   },
   {
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
PRT 3.1 fixed a bug where the CWD was modified unexpectedly by the Unreal encoder extension. We can now revert the workaround of calling getcwd before PyPRT initialization.